### PR TITLE
Fix import/export dashboards and allow bulk selection on multiple pages.

### DIFF
--- a/superset-frontend/src/components/ListView/ListView.test.jsx
+++ b/superset-frontend/src/components/ListView/ListView.test.jsx
@@ -247,6 +247,80 @@ describe('ListView', () => {
     `);
   });
 
+  it('deselects all rows after bulk delete resolves', async () => {
+    const deleteAction = jest.fn(() => Promise.resolve());
+    const wrapper2 = factory({
+      ...mockedProps,
+      bulkActions: [
+        {
+          key: 'delete',
+          name: 'delete',
+          type: 'danger',
+          onSelect: deleteAction,
+        },
+      ],
+    });
+    await waitForComponentToPaint(wrapper2);
+
+    act(() => {
+      wrapper2.find('input[id="header-toggle-all"]').at(0).prop('onChange')({
+        target: { value: 'on', checked: true },
+      });
+    });
+    wrapper2.update();
+
+    await act(async () => {
+      await wrapper2
+        .find('[data-test="bulk-select-controls"]')
+        .find(Button)
+        .props()
+        .onClick();
+    });
+    await waitForComponentToPaint(wrapper2);
+    wrapper2.update();
+
+    expect(deleteAction).toHaveBeenCalledWith(mockedProps.data);
+    wrapper2.find(IndeterminateCheckbox).forEach(input => {
+      expect(input.props().checked).toBe(false);
+    });
+  });
+
+  it('keeps selection after non-delete bulk action resolves', async () => {
+    const exportAction = jest.fn(() => Promise.resolve());
+    const wrapper2 = factory({
+      ...mockedProps,
+      bulkActions: [
+        {
+          key: 'export',
+          name: 'export',
+          type: 'primary',
+          onSelect: exportAction,
+        },
+      ],
+    });
+    await waitForComponentToPaint(wrapper2);
+
+    act(() => {
+      wrapper2.find('input[id="0"]').at(0).prop('onChange')({
+        target: { value: 'on', checked: true },
+      });
+    });
+    wrapper2.update();
+
+    await act(async () => {
+      await wrapper2
+        .find('[data-test="bulk-select-controls"]')
+        .find(Button)
+        .props()
+        .onClick();
+    });
+    await waitForComponentToPaint(wrapper2);
+    wrapper2.update();
+
+    expect(exportAction).toHaveBeenCalledWith([mockedProps.data[0]]);
+    expect(wrapper2.find('input[id="0"]').at(0).props().checked).toBe(true);
+  });
+
   it('handles bulk actions on all rows', () => {
     act(() => {
       wrapper.find('input[id="header-toggle-all"]').at(0).prop('onChange')({

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -17,7 +17,13 @@
  * under the License.
  */
 import { t, styled } from '@superset-ui/core';
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import Alert from 'src/components/Alert';
 import cx from 'classnames';
 import Button from 'src/components/Button';
@@ -120,20 +126,6 @@ const BulkSelectWrapper = styled(Alert)`
     }
   `}
 `;
-
-const bulkSelectColumnConfig = {
-  Cell: ({ row }: any) => (
-    <IndeterminateCheckbox {...row.getToggleRowSelectedProps()} id={row.id} />
-  ),
-  Header: ({ getToggleAllRowsSelectedProps }: any) => (
-    <IndeterminateCheckbox
-      {...getToggleAllRowsSelectedProps()}
-      id="header-toggle-all"
-    />
-  ),
-  id: 'selection',
-  size: 'sm',
-};
 
 const ViewModeContainer = styled.div`
   padding-right: ${({ theme }) => theme.gridUnit * 4}px;
@@ -249,6 +241,80 @@ function ListView<T extends object = any>({
   highlightRowId,
   emptyState,
 }: ListViewProps<T>) {
+  const [selectedRowsMap, setSelectedRowsMap] = useState<Record<string, T>>({});
+  const selectedRowsMapRef = useRef<Record<string, T>>({});
+
+  // Dynamic bulk-select column config: persists row data directly into
+  // selectedRowsMapRef on each checkbox toggle so selections survive page
+  // navigation without any reconciliation effect.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const bulkSelectColumnConfig = useMemo(
+    () => ({
+      Cell: ({ row }: any) => {
+        const toggleProps = row.getToggleRowSelectedProps();
+        return (
+          <IndeterminateCheckbox
+            {...toggleProps}
+            id={row.id}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              toggleProps.onChange(e);
+              if (e.target.checked) {
+                selectedRowsMapRef.current = {
+                  ...selectedRowsMapRef.current,
+                  [row.id]: row.original,
+                };
+              } else {
+                const { [row.id]: _removed, ...rest } =
+                  selectedRowsMapRef.current;
+                selectedRowsMapRef.current = rest;
+              }
+              setSelectedRowsMap({ ...selectedRowsMapRef.current });
+            }}
+          />
+        );
+      },
+      Header: ({ getToggleAllRowsSelectedProps, rows: tableRows }: any) => {
+        const toggleProps = getToggleAllRowsSelectedProps();
+        return (
+          <IndeterminateCheckbox
+            {...toggleProps}
+            id="header-toggle-all"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              toggleProps.onChange(e);
+              if (e.target.checked) {
+                const additions: Record<string, T> = {};
+                tableRows.forEach((row: any) => {
+                  additions[row.id] = row.original;
+                });
+                selectedRowsMapRef.current = {
+                  ...selectedRowsMapRef.current,
+                  ...additions,
+                };
+              } else {
+                const currentPageIds = new Set<string>(
+                  tableRows.map((row: any) => String(row.id)),
+                );
+                const filtered: Record<string, T> = {};
+                (
+                  Object.entries(selectedRowsMapRef.current) as [string, T][]
+                ).forEach(([id, row]) => {
+                  if (!currentPageIds.has(id)) {
+                    filtered[id] = row;
+                  }
+                });
+                selectedRowsMapRef.current = filtered;
+              }
+              setSelectedRowsMap({ ...selectedRowsMapRef.current });
+            }}
+          />
+        );
+      },
+      id: 'selection',
+      size: 'sm',
+    }),
+    [],
+  );
+
   const {
     getTableProps,
     getTableBodyProps,
@@ -258,7 +324,7 @@ function ListView<T extends object = any>({
     pageCount = 1,
     gotoPage,
     applyFilterValue,
-    selectedFlatRows,
+    selectedRowIds,
     toggleAllRowsSelected,
     setViewMode,
     state: { pageIndex, pageSize, internalFilters, viewMode },
@@ -299,12 +365,44 @@ function ListView<T extends object = any>({
     }
   }, [query.filters]);
 
+  const handleDeselectAll = useCallback(() => {
+    toggleAllRowsSelected(false);
+    selectedRowsMapRef.current = {};
+    setSelectedRowsMap({});
+  }, [toggleAllRowsSelected]);
+
+  const selectedRows = useMemo(
+    () => Object.values(selectedRowsMap),
+    [selectedRowsMap],
+  );
+
+  const handleBulkActionClick = useCallback(
+    async (action: NonNullable<ListViewProps<T>['bulkActions']>[number]) => {
+      await Promise.resolve(action.onSelect(selectedRows));
+      if (action.key === 'delete') {
+        handleDeselectAll();
+      }
+    },
+    [handleDeselectAll, selectedRows],
+  );
+
   const cardViewEnabled = Boolean(renderCard);
 
   useEffect(() => {
     // discard selections if bulk select is disabled
     if (!bulkSelectEnabled) toggleAllRowsSelected(false);
   }, [bulkSelectEnabled, toggleAllRowsSelected]);
+
+  // Clear the map when bulk-select is disabled or all rows are deselected
+  // (e.g. via the "Deselect all" button which calls toggleAllRowsSelected(false)).
+  useEffect(() => {
+    if (!bulkSelectEnabled || !Object.keys(selectedRowIds || {}).length) {
+      selectedRowsMapRef.current = {};
+      setSelectedRowsMap((current: Record<string, T>) =>
+        Object.keys(current).length ? {} : current,
+      );
+    }
+  }, [bulkSelectEnabled, selectedRowIds]);
 
   return (
     <ListViewStyles>
@@ -344,16 +442,16 @@ function ListView<T extends object = any>({
               message={
                 <>
                   <div className="selectedCopy" data-test="bulk-select-copy">
-                    {renderBulkSelectCopy(selectedFlatRows)}
+                    {renderBulkSelectCopy(selectedRows)}
                   </div>
-                  {Boolean(selectedFlatRows.length) && (
+                  {Boolean(selectedRows.length) && (
                     <>
                       <span
                         data-test="bulk-select-deselect-all"
                         role="button"
                         tabIndex={0}
                         className="deselect-all"
-                        onClick={() => toggleAllRowsSelected(false)}
+                        onClick={handleDeselectAll}
                       >
                         {t('Deselect all')}
                       </span>
@@ -364,11 +462,7 @@ function ListView<T extends object = any>({
                           key={action.key}
                           buttonStyle={action.type}
                           cta
-                          onClick={() =>
-                            action.onSelect(
-                              selectedFlatRows.map(r => r.original),
-                            )
-                          }
+                          onClick={() => handleBulkActionClick(action)}
                         >
                           {action.name}
                         </Button>

--- a/superset-frontend/src/components/ListView/utils.ts
+++ b/superset-frontend/src/components/ListView/utils.ts
@@ -69,6 +69,13 @@ export class ListViewError extends Error {
   name = 'ListViewError';
 }
 
+function getRowIdentifier(row: Record<string, any>, rowIndex: number) {
+  if (typeof row.id !== 'undefined' && row.id !== null) {
+    return String(row.id);
+  }
+  return String(rowIndex);
+}
+
 // removes element from a list, returns new list
 export function removeFromList(list: any[], index: number): any[] {
   return list.filter((_, i) => index !== i);
@@ -259,12 +266,13 @@ export function useListViewState({
     setAllFilters,
     selectedFlatRows,
     toggleAllRowsSelected,
-    state: { pageIndex, pageSize, sortBy, filters },
+    state: { pageIndex, pageSize, sortBy, filters, selectedRowIds },
   } = useTable(
     {
       columns: columnsWithSelect,
       count,
       data,
+      getRowId: (row, rowIndex) => getRowIdentifier(row, rowIndex),
       disableFilters: true,
       disableSortRemove: true,
       initialState,
@@ -272,6 +280,7 @@ export function useListViewState({
       manualPagination: true,
       manualSortBy: true,
       autoResetFilters: false,
+      autoResetSelectedRows: false,
       pageCount: Math.ceil(count / initialPageSize),
     },
     useFilters,
@@ -373,6 +382,7 @@ export function useListViewState({
     prepareRow,
     rows,
     selectedFlatRows,
+    selectedRowIds,
     setAllFilters,
     state: { pageIndex, pageSize, sortBy, filters, internalFilters, viewMode },
     toggleAllRowsSelected,

--- a/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
+++ b/superset-frontend/src/views/CRUD/data/dataset/DatasetList.tsx
@@ -771,8 +771,8 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
               renderBulkSelectCopy={selected => {
                 const { virtualCount, physicalCount } = selected.reduce(
                   (acc, e) => {
-                    if (e.original.kind === 'physical') acc.physicalCount += 1;
-                    else if (e.original.kind === 'virtual') {
+                    if (e.kind === 'physical') acc.physicalCount += 1;
+                    else if (e.kind === 'virtual') {
                       acc.virtualCount += 1;
                     }
                     return acc;

--- a/superset/commands/importers/v1/__init__.py
+++ b/superset/commands/importers/v1/__init__.py
@@ -33,7 +33,6 @@ from superset.commands.importers.v1.utils import (
 from superset.dao.base import BaseDAO
 from superset.models.core import Database
 
-
 class ImportModelsCommand(BaseCommand):
     """Import models"""
 

--- a/superset/dashboards/commands/importers/v0.py
+++ b/superset/dashboards/commands/importers/v0.py
@@ -21,11 +21,13 @@ from copy import copy
 from datetime import datetime
 from typing import Any, Dict, Optional
 
+import yaml
 from flask_babel import lazy_gettext as _
 from sqlalchemy.orm import make_transient, Session
 
 from superset import db
 from superset.commands.base import BaseCommand
+from superset.commands.importers.exceptions import IncorrectVersionError
 from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
 from superset.datasets.commands.importers.v0 import import_dataset
 from superset.exceptions import DashboardImportException
@@ -270,8 +272,7 @@ def import_dashboard(
 
 def decode_dashboards(o: Dict[str, Any]) -> Any:
     """
-    Function to be passed into json.loads obj_hook parameter
-    Recreates the dashboard object from a json representation.
+    Recreates dashboard objects from serialized marker dictionaries.
     """
 
     if "__Dashboard__" in o:
@@ -290,6 +291,23 @@ def decode_dashboards(o: Dict[str, Any]) -> Any:
     return o
 
 
+def decode_dashboards_content(content: str) -> Any:
+    """
+    Parse YAML content and recursively decode dashboard marker objects.
+    YAML parser is used instead of JSON to support both YAML and JSON formats.
+    """
+
+    def recursive_decode(value: Any) -> Any:
+        if isinstance(value, list):
+            return [recursive_decode(item) for item in value]
+        if isinstance(value, dict):
+            decoded = {key: recursive_decode(item) for key, item in value.items()}
+            return decode_dashboards(decoded)
+        return value
+
+    return recursive_decode(yaml.safe_load(content))
+
+
 def import_dashboards(
     session: Session,
     content: str,
@@ -299,7 +317,7 @@ def import_dashboards(
     """Imports dashboards from a stream to databases"""
     current_tt = int(time.time())
     import_time = current_tt if import_time is None else import_time
-    data = json.loads(content, object_hook=decode_dashboards)
+    data = decode_dashboards_content(content)
     if not data:
         raise DashboardImportException(_("No data in file"))
     dataset_id_mapping: Dict[int, int] = {}
@@ -316,7 +334,7 @@ def import_dashboards(
 
 class ImportDashboardsCommand(BaseCommand):
     """
-    Import dashboard in JSON format.
+    Import dashboards from YAML/JSON v0 format.
 
     This is the original unversioned format used to export and import dashboards
     in Superset.
@@ -337,10 +355,18 @@ class ImportDashboardsCommand(BaseCommand):
             import_dashboards(db.session, content, self.database_id)
 
     def validate(self) -> None:
-        # ensure all files are JSON
-        for content in self.contents.values():
+        # ensure all files are YAML/JSON with dashboard v0 keys
+        for file_name, content in self.contents.items():
             try:
-                json.loads(content)
-            except ValueError:
-                logger.exception("Invalid JSON file")
-                raise
+                data = yaml.safe_load(content)
+            except yaml.YAMLError as ex:
+                logger.exception("Invalid YAML file")
+                raise IncorrectVersionError(
+                    f"{file_name} is not a valid YAML file"
+                ) from ex
+
+            if not isinstance(data, dict):
+                raise IncorrectVersionError(f"{file_name} is not a valid file")
+
+            if "datasources" not in data or "dashboards" not in data:
+                raise IncorrectVersionError(f"{file_name} has no valid keys")

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -303,6 +303,8 @@ class GetFavStarIdsSchema(Schema):
 class ImportV1DashboardSchema(Schema):
     dashboard_title = fields.String(required=True)
     description = fields.String(allow_none=True)
+    certified_by = fields.String(allow_none=True)
+    certification_details = fields.String(allow_none=True)
     css = fields.String(allow_none=True)
     slug = fields.String(allow_none=True)
     uuid = fields.UUID(required=True)

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -671,6 +671,7 @@ class ImportV1DatabaseExtraSchema(Schema):
     cost_estimate_enabled = fields.Boolean()
     allows_virtual_table_explore = fields.Boolean(required=False)
     cancel_query_on_windows_unload = fields.Boolean(required=False)
+    version = fields.String(required=False, allow_none=True)
     disable_data_preview = fields.Boolean(required=False)
 
 

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -165,6 +165,8 @@ class Dashboard(Model, AuditMixinNullable, ImportExportMixin):
         "position_json",
         "json_metadata",
         "description",
+        "certified_by",
+        "certification_details",
         "css",
         "slug",
     ]


### PR DESCRIPTION
Fix import - Added a missing version field on the schema.
Added the missing certification fields on dashboard export.
Implemented a persistence of selected rows on the dashboard/charts/datasets lists to allow the bulk selection to happen on multiple pages at once.