### PR TITLE
Implement backend API and add frontend action to send report on demand

### DIFF
--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -408,7 +408,7 @@ function AlertList({
                   label: 'trigger-now-action',
                   tooltip: t('Trigger now'),
                   placement: 'bottom',
-                  icon: 'Bolt',
+                  icon: 'BoltSmallRun',
                   onClick: () => handleTriggerNow(original),
                 }
               : null,

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -193,7 +193,7 @@ function AlertList({
   const handleTriggerNow = async (alert: AlertObject) => {
     try {
       await SupersetClient.post({
-        endpoint: `/api/v1/report/${alert.id}/trigger_now/`,
+        endpoint: `/api/v1/report/${alert.id}/trigger_now`,
       });
       addSuccessToast(
         t('Report/Alert "%s" triggered successfully', alert.name),

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -189,10 +189,11 @@ function AlertList({
     );
   };
 
-  const handleSendNow = async (alert: AlertObject) => {
+  /* NGLS - BEGIN */
+  const handleTriggerNow = async (alert: AlertObject) => {
     try {
       await SupersetClient.post({
-        endpoint: `/api/v1/report/${alert.id}/send_now/`,
+        endpoint: `/api/v1/report/${alert.id}/trigger_now/`,
       });
       addSuccessToast(
         t('Report/Alert "%s" triggered successfully', alert.name),
@@ -205,6 +206,7 @@ function AlertList({
       )(e);
     }
   };
+  /* NGLS - END */
 
   const handleBulkAlertDelete = async (alertsToDelete: AlertObject[]) => {
     try {
@@ -387,6 +389,7 @@ function AlertList({
             original.owners.map((o: Owner) => o.id).includes(user.userId) ||
             isUserAdmin(user);
 
+          /* NGLS - BEGIN */
           const actions = [
             allowEdit && canEdit
               ? {
@@ -394,9 +397,10 @@ function AlertList({
                   tooltip: t('Send Now'),
                   placement: 'bottom',
                   icon: 'Bolt',
-                  onClick: () => handleSendNow(original),
+                  onClick: () => handleTriggerNow(original),
                 }
               : null,
+            /* NGLS - END */
             canEdit
               ? {
                   label: 'execution-log-action',
@@ -435,7 +439,15 @@ function AlertList({
         size: 'xl',
       },
     ],
-    [canDelete, canEdit, isReportEnabled, toggleActive],
+    [
+      canDelete,
+      canEdit,
+      isReportEnabled,
+      toggleActive,
+      /* NGLS - BEGIN */
+      handleTriggerNow
+      /* NGLS - END */
+    ],
   );
 
   const subMenuButtons: SubMenuProps['buttons'] = [];

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -201,11 +201,15 @@ function AlertList({
     } catch (e) {
       let customErrorMsg = t('An unknown error occurred');
       if (e.status === 409) {
-        customErrorMsg = t('A report execution is already in progress for this schedule.');
+        customErrorMsg = t(
+          'A report execution is already in progress for this schedule.',
+        );
       } else if (e.status === 404) {
         customErrorMsg = t('This report no longer exists.');
       } else if (e.status === 403) {
-        customErrorMsg = t('You do not have permission to trigger this report.');
+        customErrorMsg = t(
+          'You do not have permission to trigger this report.',
+        );
       } else if (e.status === 500) {
         customErrorMsg = t('Internal server error. Please try again later.');
       }

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -199,11 +199,19 @@ function AlertList({
         t('Report/Alert "%s" triggered successfully', alert.name),
       );
     } catch (e) {
-      createErrorHandler(errMsg =>
-        addDangerToast(
-          t('There was an issue triggering %s: %s', alert.name, errMsg),
-        ),
-      )(e);
+      let customErrorMsg = t('An unknown error occurred');
+      if (e.status === 409) {
+        customErrorMsg = t('A report execution is already in progress for this schedule.');
+      } else if (e.status === 404) {
+        customErrorMsg = t('This report no longer exists.');
+      } else if (e.status === 403) {
+        customErrorMsg = t('You do not have permission to trigger this report.');
+      } else if (e.status === 500) {
+        customErrorMsg = t('Internal server error. Please try again later.');
+      }
+      addDangerToast(
+        t('There was an issue triggering %s: %s', alert.name, customErrorMsg),
+      );
     }
   };
   /* NGLS - END */
@@ -394,7 +402,7 @@ function AlertList({
             allowEdit && canEdit
               ? {
                   label: 'send-now-action',
-                  tooltip: t('Send Now'),
+                  tooltip: t('Trigger now'),
                   placement: 'bottom',
                   icon: 'Bolt',
                   onClick: () => handleTriggerNow(original),

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -401,7 +401,7 @@ function AlertList({
           const actions = [
             allowEdit && canEdit
               ? {
-                  label: 'send-now-action',
+                  label: 'trigger-now-action',
                   tooltip: t('Trigger now'),
                   placement: 'bottom',
                   icon: 'Bolt',

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -445,7 +445,7 @@ function AlertList({
       isReportEnabled,
       toggleActive,
       /* NGLS - BEGIN */
-      handleTriggerNow
+      handleTriggerNow,
       /* NGLS - END */
     ],
   );

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -189,6 +189,23 @@ function AlertList({
     );
   };
 
+  const handleSendNow = async (alert: AlertObject) => {
+    try {
+      await SupersetClient.post({
+        endpoint: `/api/v1/report/${alert.id}/exec/`,
+      });
+      addSuccessToast(
+        t('Report/Alert "%s" triggered successfully', alert.name),
+      );
+    } catch (e) {
+      createErrorHandler(errMsg =>
+        addDangerToast(
+          t('There was an issue triggering %s: %s', alert.name, errMsg),
+        ),
+      )(e);
+    }
+  };
+
   const handleBulkAlertDelete = async (alertsToDelete: AlertObject[]) => {
     try {
       const { message } = await deleteAlerts(
@@ -371,6 +388,15 @@ function AlertList({
             isUserAdmin(user);
 
           const actions = [
+            allowEdit && canEdit
+              ? {
+                label: 'send-now-action',
+                tooltip: t('Send Now'),
+                placement: 'bottom',
+                icon: 'PaperPlane',
+                onClick: () => handleSendNow(original),
+              }
+              : null,
             canEdit
               ? {
                   label: 'execution-log-action',

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -408,7 +408,7 @@ function AlertList({
                   label: 'trigger-now-action',
                   tooltip: t('Trigger now'),
                   placement: 'bottom',
-                  icon: 'BoltSmallRun',
+                  icon: 'Bolt',
                   onClick: () => handleTriggerNow(original),
                 }
               : null,

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -192,7 +192,7 @@ function AlertList({
   const handleSendNow = async (alert: AlertObject) => {
     try {
       await SupersetClient.post({
-        endpoint: `/api/v1/report/${alert.id}/exec/`,
+        endpoint: `/api/v1/report/${alert.id}/send_now/`,
       });
       addSuccessToast(
         t('Report/Alert "%s" triggered successfully', alert.name),

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -199,7 +199,7 @@ function AlertList({
         t('Report/Alert "%s" triggered successfully', alert.name),
       );
     } catch (e) {
-      let customErrorMsg = t('An unknown error occurred');
+      let customErrorMsg = t('Something went wrong. Please try again later.');
       if (e.status === 409) {
         customErrorMsg = t(
           'A report execution is already in progress for this schedule.',

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -199,7 +199,7 @@ function AlertList({
         t('Report/Alert "%s" triggered successfully', alert.name),
       );
     } catch (e) {
-    // TO DO: Support validation and error handling for manual report dispatch.  
+      // TO DO: Support validation and error handling for manual report dispatch.
       let customErrorMsg = t('Something went wrong. Please try again later.');
       if (e.status === 409) {
         customErrorMsg = t(

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -199,6 +199,7 @@ function AlertList({
         t('Report/Alert "%s" triggered successfully', alert.name),
       );
     } catch (e) {
+    // TO DO: Support validation and error handling for manual report dispatch.  
       let customErrorMsg = t('Something went wrong. Please try again later.');
       if (e.status === 409) {
         customErrorMsg = t(

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -390,12 +390,12 @@ function AlertList({
           const actions = [
             allowEdit && canEdit
               ? {
-                label: 'send-now-action',
-                tooltip: t('Send Now'),
-                placement: 'bottom',
-                icon: 'PaperPlane',
-                onClick: () => handleSendNow(original),
-              }
+                  label: 'send-now-action',
+                  tooltip: t('Send Now'),
+                  placement: 'bottom',
+                  icon: 'PaperPlane',
+                  onClick: () => handleSendNow(original),
+                }
               : null,
             canEdit
               ? {

--- a/superset-frontend/src/views/CRUD/alert/AlertList.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertList.tsx
@@ -393,7 +393,7 @@ function AlertList({
                   label: 'send-now-action',
                   tooltip: t('Send Now'),
                   placement: 'bottom',
-                  icon: 'PaperPlane',
+                  icon: 'Bolt',
                   onClick: () => handleSendNow(original),
                 }
               : null,

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -519,7 +519,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
             return self.response_422(message=str(ex))
 
     # NGLS - BEGIN
-    @expose("/<int:pk>/trigger_now/", methods=["POST"])
+    @expose("/<int:pk>/trigger_now", methods=["POST"])
     @protect()
     @safe
     @permission_name("trigger_now")

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 from flask import request, Response
@@ -51,6 +52,7 @@ from superset.reports.schemas import (
     ReportSchedulePostSchema,
     ReportSchedulePutSchema,
 )
+from superset.tasks.scheduler import execute
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
     RelatedFieldFilter,
@@ -74,6 +76,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     include_route_methods = RouteMethod.REST_MODEL_VIEW_CRUD_SET | {
         RouteMethod.RELATED,
         "bulk_delete",  # not using RouteMethod since locally defined
+        "send_now",
     }
     class_permission_name = "ReportSchedule"
     method_permission_name = MODEL_API_RW_METHOD_PERMISSION_MAP
@@ -508,3 +511,43 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
             return self.response_403()
         except ReportScheduleBulkDeleteFailedError as ex:
             return self.response_422(message=str(ex))
+
+    @expose("/<int:pk>/send_now/", methods=["POST"])
+    @protect()
+    @safe
+    @permission_name("post")
+    @statsd_metrics
+    def send_now(self, pk: int) -> Response:
+        """
+        Trigger a Report Schedule execution immediately.
+        """
+
+        try:
+            report_schedule = self.datamodel.get(pk)
+
+            if not report_schedule:
+                return self.response_404()
+
+            scheduled_dttm = datetime.now(timezone.utc)
+
+            execute.apply_async(
+                (
+                    pk,
+                    scheduled_dttm.isoformat(),
+                )
+            )
+
+            return self.response(
+                200,
+                message="Report triggered successfully",
+            )
+
+        except Exception as ex:
+            logger.exception(
+                "Error triggering report schedule %s",
+                pk,
+            )
+
+            return self.response_500(
+                message=str(ex),
+            )

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -525,12 +525,11 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     @permission_name("trigger_now")
     @statsd_metrics
     @event_logger.log_this_with_context(
-    action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.trigger_now",
-    log_to_statsd=False,
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.trigger_now",
+        log_to_statsd=False,
     )
     def trigger_now(self, pk: int) -> Response:
-        """
-        Trigger a Report Schedule execution immediately.
+        """Trigger a Report Schedule execution immediately
         ---
         post:
           description: >-
@@ -542,49 +541,26 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
               type: integer
             name: pk
             required: true
-            description: The Report Schedule id
+            description: The Report Schedule pk
           responses:
             200:
-              description: Report schedule triggered successfully
-              content:
-                application/json:
-                  schema:
-                    type: object
-                    properties:
-                      message:
-                        type: string
-                        example: Report triggered successfully
+              $ref: '#/components/responses/200'
             403:
               $ref: '#/components/responses/403'
             404:
               $ref: '#/components/responses/404'
             409:
-              description: A report execution is already in progress
-              content:
-                application/json:
-                  schema:
-                    type: object
-                    properties:
-                      message:
-                        type: string
+              $ref: '#/components/responses/409'
             500:
               $ref: '#/components/responses/500'
         """
-
         try:
             report_schedule = self.datamodel.get(pk)
-
             if not report_schedule:
                 return self.response_404()
-
             if report_schedule.last_state == ReportState.WORKING:
-                return self.response(
-                    409,
-                    message="A report execution is already in progress for this schedule",
-                )
-
+                return self.response(409)
             scheduled_dttm = datetime.now(timezone.utc)
-
             execute.apply_async(
                 (
                     pk,
@@ -592,19 +568,13 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
                     True,
                 )
             )
-
-            return self.response(
-                200,
-                message="Report triggered successfully",
-            )
-
+            return self.response(200)
         except Exception as ex:
-            logger.exception(
-                "Error triggering report schedule %s",
-                pk,
+            logger.error(
+                "Error triggering report schedule %s: %s",
+                self.__class__.__name__,
+                str(ex),
+                exc_info=True,
             )
-
-            return self.response_500(
-                message=str(ex),
-            )
+            return self.response_500()
     # NGLS - END

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -47,7 +47,7 @@ from superset.reports.commands.exceptions import (
 )
 from superset.reports.commands.update import UpdateReportScheduleCommand
 from superset.reports.filters import ReportScheduleAllTextFilter, ReportScheduleFilter
-from superset.reports.models import ReportSchedule
+from superset.reports.models import ReportSchedule, ReportState
 from superset.reports.schemas import (
     get_delete_ids_schema,
     openapi_spec_methods_override,
@@ -558,6 +558,15 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
               $ref: '#/components/responses/403'
             404:
               $ref: '#/components/responses/404'
+            409:
+              description: A report execution is already in progress
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      message:
+                        type: string
             500:
               $ref: '#/components/responses/500'
         """
@@ -568,12 +577,19 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
             if not report_schedule:
                 return self.response_404()
 
+            if report_schedule.last_state == ReportState.WORKING:
+                return self.response(
+                    409,
+                    message="A report execution is already in progress for this schedule",
+                )
+
             scheduled_dttm = datetime.now(timezone.utc)
 
             execute.apply_async(
                 (
                     pk,
                     scheduled_dttm.isoformat(),
+                    True,
                 )
             )
 

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -515,7 +515,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     @expose("/<int:pk>/send_now/", methods=["POST"])
     @protect()
     @safe
-    @permission_name("post")
+    @permission_name("send_now")
     @statsd_metrics
     def send_now(self, pk: int) -> Response:
         """

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -15,7 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+# NGLS - BEGIN
 from datetime import datetime, timezone
+# NGLS - END
 from typing import Any, Optional
 
 from flask import request, Response
@@ -52,7 +54,9 @@ from superset.reports.schemas import (
     ReportSchedulePostSchema,
     ReportSchedulePutSchema,
 )
+# NGLS - BEGIN
 from superset.tasks.scheduler import execute
+# NGLS - END
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
     RelatedFieldFilter,
@@ -76,7 +80,9 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
     include_route_methods = RouteMethod.REST_MODEL_VIEW_CRUD_SET | {
         RouteMethod.RELATED,
         "bulk_delete",  # not using RouteMethod since locally defined
-        "send_now",
+        # NGLS - BEGIN
+        "trigger_now",
+        # NGLS - END
     }
     class_permission_name = "ReportSchedule"
     method_permission_name = MODEL_API_RW_METHOD_PERMISSION_MAP
@@ -512,14 +518,48 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
         except ReportScheduleBulkDeleteFailedError as ex:
             return self.response_422(message=str(ex))
 
-    @expose("/<int:pk>/send_now/", methods=["POST"])
+    # NGLS - BEGIN
+    @expose("/<int:pk>/trigger_now/", methods=["POST"])
     @protect()
     @safe
-    @permission_name("send_now")
+    @permission_name("trigger_now")
     @statsd_metrics
-    def send_now(self, pk: int) -> Response:
+    @event_logger.log_this_with_context(
+    action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.trigger_now",
+    log_to_statsd=False,
+    )
+    def trigger_now(self, pk: int) -> Response:
         """
         Trigger a Report Schedule execution immediately.
+        ---
+        post:
+          description: >-
+            Trigger a Report Schedule execution immediately and send the report to
+            configured recipients.
+          parameters:
+          - in: path
+            schema:
+              type: integer
+            name: pk
+            required: true
+            description: The Report Schedule id
+          responses:
+            200:
+              description: Report schedule triggered successfully
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                        example: Report triggered successfully
+            403:
+              $ref: '#/components/responses/403'
+            404:
+              $ref: '#/components/responses/404'
+            500:
+              $ref: '#/components/responses/500'
         """
 
         try:
@@ -551,3 +591,4 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
             return self.response_500(
                 message=str(ex),
             )
+    # NGLS - END

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -74,15 +74,16 @@ def scheduler() -> None:
 
 
 @celery_app.task(name="reports.execute", bind=True)
-def execute(self: Celery.task, report_schedule_id: int, scheduled_dttm: str) -> None:
+def execute(self: Celery.task, report_schedule_id: int, scheduled_dttm: str, trigger_now: bool = False,) -> None:
     task_id = None
     try:
         task_id = execute.request.id
         scheduled_dttm_ = parser.parse(scheduled_dttm)
         logger.info(
-            "Executing alert/report, task id: %s, scheduled_dttm: %s",
+            "Executing alert/report, task id: %s, scheduled_dttm: %s, trigger_now: %s",
             task_id,
             scheduled_dttm,
+            trigger_now,
         )
         AsyncExecuteReportScheduleCommand(
             task_id,


### PR DESCRIPTION
## NGLS-4685

### SUMMARY

Adds support for manually triggering a Report Schedule execution from the Reports UI.

This change introduces a new **Trigger now** action that allows users to immediately execute a scheduled report and send it to the configured recipients without waiting for the next scheduled run.

The implementation includes:
- A new backend endpoint (`POST /api/v1/report/<id>/trigger_now/`) to trigger report execution on demand.
- A new **Trigger now** action in the Report Schedule list using the `Bolt` icon.
- Support for manual executions in the report scheduler task.
- Success and error notifications for common execution scenarios (concurrent execution, missing report, permission errors, and unexpected failures).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1919" height="532" alt="image" src="https://github.com/user-attachments/assets/025053dc-11b7-444c-a737-00868d6af623" />
<img width="1914" height="915" alt="image" src="https://github.com/user-attachments/assets/06009616-533f-4e62-bfbd-ede4c7e24bf8" />
<img width="1911" height="908" alt="image" src="https://github.com/user-attachments/assets/3b680189-4f0d-4107-89c6-efbcdf935527" />

### TESTING INSTRUCTIONS

1. Log in as an admin user.
2. Create or use an existing Report Schedule.
3. Open **Reports**.
4. Click **Trigger now** from the actions menu.
5. Verify that a success toast is displayed indicating the report was triggered successfully.

### ADDITIONAL INFORMATION

- [x] Has associated issue: NGLS-4685
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API